### PR TITLE
Add optional low_background_flag to df_f_calculation.py to curb unrealistically high dF/F values

### DIFF
--- a/dff_calc/df_f_calculation.py
+++ b/dff_calc/df_f_calculation.py
@@ -24,7 +24,7 @@ def dff_calc(
     Parameters
     ----------
     data : np.ndarray
-        dF/F traces with dimensions (cell x time)
+        Fluorescence traces with dimensions (cell x time)
     fps : float, optional
         Frame rate (Hz)
     tau_0 : float, optional

--- a/dff_calc/df_f_calculation.py
+++ b/dff_calc/df_f_calculation.py
@@ -89,7 +89,7 @@ def _calc_dff_unfiltered(f0: pd.DataFrame, data: np.ndarray, low_background_flag
     """ Subtract baseline from current fluorescence """
     f0 = f0.to_numpy()
     if low_background_flag:
-        raw_calc = (data.T  - f0) / (f0 + low_background_offset_value) # artificially increasing the baseline for low-background imaging modalities, so as to prevent unrealistically high dF/F values.
+        raw_calc = (data.T  + 2*low_background_offset_value - f0) / (f0 + low_background_offset_value) # artificially increasing the baseline for low-background imaging modalities, so as to prevent unrealistically high dF/F values when F0 is 0, and negative dF when F is 0.
     else:
         raw_calc = (data.T - f0) / f0
     unfiltered_dff = pd.DataFrame(raw_calc).fillna(0)

--- a/dff_calc/df_f_calculation.py
+++ b/dff_calc/df_f_calculation.py
@@ -9,6 +9,7 @@ def dff_calc(
     tau_1: float = 0.35,
     tau_2: float = 2.0,
     invert: bool = False,
+    low_background_flag: bool = False,
 ):
     """Calculates dF/F from calcium traces, based on
     https://www.nature.com/articles/nprot.2010.169.
@@ -35,12 +36,15 @@ def dff_calc(
     invert : bool, optional
         False (default) if the transient is expected to be positive, True
         otherwise.
+    low_background_flag : bool, optional
+        False (default) if the baseline is strictly positive, as in analog imaging. True for low background recordings, e.g. photon counting, three-photon excitation or sparse acquisition.
 
     Returns
     -------
     dff : np.ndarray
         A 2D array, each row being a calculated dF/F trace.
     """
+    low_background_offset_value = 0.05
     tau_0, tau_1, tau_2, min_per = _apply_units_and_corrections(
         fps, tau_0, tau_1, tau_2
     )
@@ -48,7 +52,7 @@ def dff_calc(
         data = -data
 
     f0 = _calc_f0(data, tau_1, tau_2, min_per)
-    unfiltered_dff = _calc_dff_unfiltered(f0, data)
+    unfiltered_dff = _calc_dff_unfiltered(f0, data, low_background_flag, low_background_offset_value)
     dff = _filter_dff(unfiltered_dff, tau_0, min_per)
     if data.ndim == 1:
         return np.atleast_2d(dff.to_numpy().ravel())
@@ -77,13 +81,17 @@ def _calc_f0(
         .min()
         + np.finfo(float).eps
     )
+
     return f0
 
 
-def _calc_dff_unfiltered(f0: pd.DataFrame, data: np.ndarray):
+def _calc_dff_unfiltered(f0: pd.DataFrame, data: np.ndarray, low_background_flag: bool, low_background_offset_value=0.0):
     """ Subtract baseline from current fluorescence """
     f0 = f0.to_numpy()
-    raw_calc = (data.T - f0) / f0
+    if low_background_flag:
+        raw_calc = (data.T  - f0) / (f0 + low_background_offset_value) # artificially increasing the baseline for low-background imaging modalities, so as to prevent unrealistically high dF/F values.
+    else:
+        raw_calc = (data.T - f0) / f0
     unfiltered_dff = pd.DataFrame(raw_calc).fillna(0)
     return unfiltered_dff
 
@@ -92,3 +100,4 @@ def _filter_dff(unfiltered_dff: pd.DataFrame, tau_0: float, min_per: int):
     """Apply an exponentially weighted moving average to the dF/F data. """
     dff = unfiltered_dff.ewm(halflife=tau_0, min_periods=min_per).mean().fillna(0)
     return dff
+


### PR DESCRIPTION
Added an optional boolean low_background_flag: False (default) if the baseline is strictly positive, as in analog imaging. True for low background recordings, e.g. photon counting, three-photon excitation or sparse acquisition.
If True, delta_F is divided by (f0 + low_background_offset_value), artificially increasing the baseline for low-background imaging modalities, so as to prevent unrealistically high dF/F values.